### PR TITLE
Fix Resolver API use

### DIFF
--- a/src/main/java/org/rapaio/jupyter/kernel/core/magic/dependencies/MimaDependencyManager.java
+++ b/src/main/java/org/rapaio/jupyter/kernel/core/magic/dependencies/MimaDependencyManager.java
@@ -102,12 +102,6 @@ public class MimaDependencyManager {
         CollectRequest collectRequest = new CollectRequest(root, dependencies, context.remoteRepositories());
         DependencyRequest dependencyRequest = new DependencyRequest(collectRequest, null);
 
-        context.repositorySystem().resolveDependencies(context.repositorySystemSession(), dependencyRequest);
-
-        // This is intentionally repeated!
-        // I do not understand why at first try the local artifacts are missing, I suppose it is due to the
-        // my lack of understanding on how maven works
-        // However, at the second time the local files are properly updated and collected
         return context.repositorySystem().resolveDependencies(context.repositorySystemSession(), dependencyRequest);
     }
 

--- a/src/main/java/org/rapaio/jupyter/kernel/core/magic/handlers/DependencyHandler.java
+++ b/src/main/java/org/rapaio/jupyter/kernel/core/magic/handlers/DependencyHandler.java
@@ -243,8 +243,8 @@ public class DependencyHandler extends MagicHandler {
             kernel.channels().writeToStdOut("Resolved artifacts count: " + artifactsResults.size() + "\n");
             for (var result : artifactsResults) {
                 kernel.channels().writeToStdOut("Add to classpath: " +
-                        ANSI.start().fgGreen().text(result.getLocalArtifactResult().getFile().getAbsolutePath()).reset().nl().render());
-                kernel.javaEngine().getShell().addToClasspath(result.getLocalArtifactResult().getFile().getAbsolutePath());
+                        ANSI.start().fgGreen().text(result.getArtifact().getFile().getAbsolutePath()).reset().nl().render());
+                kernel.javaEngine().getShell().addToClasspath(result.getArtifact().getFile().getAbsolutePath());
                 kernel.dependencyManager().addLoadedArtifact(result);
             }
             kernel.dependencyManager().promoteDependencies();

--- a/src/test/java/org/rapaio/jupyter/kernel/core/magic/dependencies/MimaDependencyManagerTest.java
+++ b/src/test/java/org/rapaio/jupyter/kernel/core/magic/dependencies/MimaDependencyManagerTest.java
@@ -112,9 +112,9 @@ public class MimaDependencyManagerTest {
         DependencyResult report = dm.resolve();
         assertNotNull(report.getArtifactResults());
         assertEquals(2, report.getArtifactResults().size());
-        assertTrue(report.getArtifactResults().getFirst().getLocalArtifactResult().getFile()
+        assertTrue(report.getArtifactResults().getFirst().getArtifact().getFile()
                         .getAbsolutePath().endsWith("lwjgl-glfw-3.3.3-natives-macos-arm64.jar"));
-        assertTrue(report.getArtifactResults().get(1).getLocalArtifactResult().getFile()
+        assertTrue(report.getArtifactResults().get(1).getArtifact().getFile()
                 .getAbsolutePath().endsWith("lwjgl-3.3.3.jar"));
     }
 }


### PR DESCRIPTION
The "local artifact result" is non-null ONLY if result comes from local maven repository (was once already resolved and cached). It should not be used, as you are not really interested in this.

Just use "artifact" instead, that is non-null even on first call (when local repo still does not have it and is downloaded from somewhere).

Fixes #70 