### PR TITLE
Add support for withUserSettings and switch to standalone-sisu MIMA

### DIFF
--- a/rapaio-jupyter-kernel/pom.xml
+++ b/rapaio-jupyter-kernel/pom.xml
@@ -35,12 +35,12 @@
         <dependency>
             <groupId>eu.maveniverse.maven.mima</groupId>
             <artifactId>context</artifactId>
-            <version>2.4.37</version>
+            <version>2.4.43</version>
         </dependency>
         <dependency>
             <groupId>eu.maveniverse.maven.mima.runtime</groupId>
-            <artifactId>standalone-static</artifactId>
-            <version>2.4.37</version>
+            <artifactId>standalone-sisu</artifactId>
+            <version>2.4.43</version>
             <scope>runtime</scope>
         </dependency>
         <!-- logging: runtime scope -->

--- a/rapaio-jupyter-kernel/resources/profile-default.properties
+++ b/rapaio-jupyter-kernel/resources/profile-default.properties
@@ -3,6 +3,7 @@ kernel.version=3.0.2
 default.display.name=Java (rjk 3.0.2)
 default.kernel.dir=rapaio-jupyter-kernel
 default.mima.cache=mima_cache
+default.mima.user.settings=false
 default.jar.name=rapaio-jupyter-kernel.jar
 default.timeout.limits=-1
 default.compiler.options=

--- a/rapaio-jupyter-kernel/src/org/rapaio/jupyter/kernel/GeneralProperties.java
+++ b/rapaio-jupyter-kernel/src/org/rapaio/jupyter/kernel/GeneralProperties.java
@@ -57,6 +57,10 @@ public final class GeneralProperties {
         return properties.getProperty("default.mima.cache");
     }
 
+    public boolean getDefaultMimaUserSettings() {
+        return Boolean.parseBoolean(properties.getProperty("default.mima.user.settings", "false"));
+    }
+
     public String[] getDefaultJavaArgv() {
         String javaArgv = properties.getProperty("default.java.argv");
         if (javaArgv == null) {

--- a/rapaio-jupyter-kernel/src/org/rapaio/jupyter/kernel/core/KernelEnv.java
+++ b/rapaio-jupyter-kernel/src/org/rapaio/jupyter/kernel/core/KernelEnv.java
@@ -4,6 +4,7 @@ import static org.rapaio.jupyter.kernel.core.RapaioKernel.RJK_CLASSPATH;
 import static org.rapaio.jupyter.kernel.core.RapaioKernel.RJK_COMPILER_OPTIONS;
 import static org.rapaio.jupyter.kernel.core.RapaioKernel.RJK_INIT_SCRIPT;
 import static org.rapaio.jupyter.kernel.core.RapaioKernel.RJK_MIMA_CACHE;
+import static org.rapaio.jupyter.kernel.core.RapaioKernel.RJK_MIMA_USER_SETTINGS;
 import static org.rapaio.jupyter.kernel.core.RapaioKernel.RJK_TIMEOUT_MILLIS;
 
 import java.io.BufferedReader;
@@ -26,6 +27,7 @@ public class KernelEnv {
     private final String initScriptContent;
     private final String classpath;
     private final String mimaCache;
+    private final boolean mimaUserSettings;
 
     public KernelEnv() {
         String envCompilerOptions = System.getenv(RJK_COMPILER_OPTIONS);
@@ -70,6 +72,14 @@ public class KernelEnv {
             LOGGER.finest("Since " + RJK_MIMA_CACHE + " is empty, default value is '" + envMimaCache + "'");
         }
         mimaCache = envMimaCache;
+
+        String envMimaUserSettings = System.getenv(RJK_MIMA_USER_SETTINGS);
+        LOGGER.finest(RJK_MIMA_USER_SETTINGS + " env: " + envMimaUserSettings);
+        if (envMimaUserSettings == null) {
+            mimaUserSettings = GeneralProperties.defaultProperties().getDefaultMimaUserSettings();
+        } else {
+            mimaUserSettings = Boolean.parseBoolean(envMimaUserSettings);
+        }
     }
 
     private String loadInitScript(String path) {
@@ -110,5 +120,9 @@ public class KernelEnv {
 
     public String mimaCache() {
         return mimaCache;
+    }
+
+    public boolean mimaUserSettings() {
+        return mimaUserSettings;
     }
 }

--- a/rapaio-jupyter-kernel/src/org/rapaio/jupyter/kernel/core/RapaioKernel.java
+++ b/rapaio-jupyter-kernel/src/org/rapaio/jupyter/kernel/core/RapaioKernel.java
@@ -60,6 +60,7 @@ public class RapaioKernel {
     public static final String RJK_INIT_SCRIPT = "RJK_INIT_SCRIPT";
     public static final String RJK_CLASSPATH = "RJK_CLASSPATH";
     public static final String RJK_MIMA_CACHE = "RJK_MIMA_CACHE";
+    public static final String RJK_MIMA_USER_SETTINGS = "RJK_MIMA_USER_SETTINGS";
 
     private static final String SHELL_INIT_RESOURCE_PATH = "init.jshell";
 

--- a/rapaio-jupyter-kernel/src/org/rapaio/jupyter/kernel/core/magic/dependencies/MimaDependencyManager.java
+++ b/rapaio-jupyter-kernel/src/org/rapaio/jupyter/kernel/core/magic/dependencies/MimaDependencyManager.java
@@ -32,6 +32,7 @@ public class MimaDependencyManager {
 
     private final ContextOverrides contextOverrides;
     private final List<RemoteRepository> remoteRepositories;
+    private final boolean userSettingsEnabled;
 
     private final List<DependencySpec> proposedDependencies = new ArrayList<>();
     private final List<DependencySpec> resolvedDependencies = new ArrayList<>();
@@ -45,8 +46,10 @@ public class MimaDependencyManager {
                 kernelPath = kernelPath.substring(1);
             }
         }
+        this.userSettingsEnabled = kernelEnv.mimaUserSettings();
         this.contextOverrides = ContextOverrides.create()
                 .withLocalRepositoryOverride(Path.of(kernelPath.substring(0, kernelPath.lastIndexOf('/')), kernelEnv.mimaCache()))
+                .withUserSettings(this.userSettingsEnabled)
                 .snapshotUpdatePolicy(ContextOverrides.SnapshotUpdatePolicy.ALWAYS).build();
         this.remoteRepositories = new ArrayList<>();
         remoteRepositories.add(ContextOverrides.CENTRAL);
@@ -99,6 +102,7 @@ public class MimaDependencyManager {
         try (Context context = Runtimes.INSTANCE.getRuntime().create(
                 contextOverrides.toBuilder()
                         .repositories(remoteRepositories)
+                        .withUserSettings(userSettingsEnabled)
                         .addRepositoriesOp(ContextOverrides.AddRepositoriesOp.REPLACE)
                         .build())) {
             List<Dependency> dependencies = new ArrayList<>();


### PR DESCRIPTION
Thanks for your work. 

We need to authenticate against secured (i.e., non-public) repositories via a settings.xml (maven) file. Unfortunately, this doesn't appear possible with the current setup so I made minimal changes to support withUserSettings from the MIMA project which checks for the presence of settings.xml. I had to use the standalone-sisu variant of MIMA to support parsing the XML.

I figured I contribute this small patch back. I think it will help in adoption of the project for people/companies/entities also needing authentication with secured repositories.